### PR TITLE
Change to use reference in separated data module

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -9,7 +9,7 @@ conda_dir = config["conda_dir"]
 scripts_dir = config["workflow_dir"] + "/scripts"
 
 # Declare the variables and files needed for the reference genome
-reference = config["workflow_dir"] + "/reference/GRCh38.fa"
+reference = config["reference_dir"] + "/GRCh38.fa"
 chromosome_sizes = config["workflow_dir"] + "/reference/GRCh38_chromosome_sizes.tsv"
 high_frequency_kmers = config["workflow_dir"] + "/reference/GRCh38_high_frequency_kmers.txt"
 genome_gaps = config["workflow_dir"] + "/reference/GRCh38_gaps.bed"


### PR DESCRIPTION
Change to use reference in separated data module, reference directory will be created in wdl workflow, which will be pointing to data module that will be loaded when workflow running
The reason for this change is code module (nanopore-sv-analysis in this case) can't have dependency on data module (hg38-nanopore-sv-reference), so the reference file can't be set in nanopore-sv-analysis module, data module needs be loaded when workflow run.